### PR TITLE
Upgrade Stash dependencies to 3.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
 
 	<properties>
 		<!-- DEPENDENCY VERSIONS -->
-		<stash.version>2.8.4</stash.version>
-		<stash.data.version>2.8.4</stash.data.version>
+		<stash.version>3.7.2</stash.version>
+		<stash.data.version>3.7.2</stash.data.version>
 		<slf4j.version>1.7.5</slf4j.version>
 		<jackson-databind.version>2.4.1.3</jackson-databind.version>
 		<joda-time.version>2.3</joda-time.version>

--- a/src/main/java/com/infobip/jira/IssueKey.java
+++ b/src/main/java/com/infobip/jira/IssueKey.java
@@ -15,7 +15,7 @@
  */
 package com.infobip.jira;
 
-import com.atlassian.stash.content.Changeset;
+import com.atlassian.stash.commit.Commit;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
@@ -44,13 +44,13 @@ public class IssueKey {
     private final IssueId issueId;
 
     /**
-     * Generates {@link IssueKey IssueKeys} from {@link Changeset#getMessage()}  changesets message}.
+     * Generates {@link IssueKey IssueKeys} from {@link Commit#getMessage()}  changesets message}.
      *
      * @param changeset containing message with Jira issue key
      *
      * @return all {@link IssueKey IssueKeys} that could be extracted from
      */
-    public static Iterable<IssueKey> of(Changeset changeset) {
+    public static Iterable<IssueKey> of(Commit changeset) {
 
         Matcher matcher = pattern.matcher(changeset.getMessage());
 
@@ -64,13 +64,13 @@ public class IssueKey {
     }
 
     /**
-     * Generates {@link IssueKey} from {@link Changeset changesets} message.
+     * Generates {@link IssueKey} from {@link Commit changesets} message.
      *
      * @param changeset containing message with Jira issue key
      *
      * @return first {@link IssueKey} that could be extracted, else {@link Optional#absent()}
      */
-    public static Optional<IssueKey> from(Changeset changeset) {
+    public static Optional<IssueKey> from(Commit changeset) {
 
         Matcher matcher = pattern.matcher(changeset.getMessage());
 

--- a/src/main/java/com/infobip/jira/JiraVersionGenerator.java
+++ b/src/main/java/com/infobip/jira/JiraVersionGenerator.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import com.atlassian.applinks.api.CredentialsRequiredException;
 import com.atlassian.sal.api.net.ResponseException;
-import com.atlassian.stash.content.Changeset;
+import com.atlassian.stash.commit.Commit;
 import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,13 +36,13 @@ public class JiraVersionGenerator {
     private static final Logger logger = LoggerFactory.getLogger(JiraVersionGenerator.class);
 
     private final JiraService jiraService;
-    private final Changeset releaseChangeset;
-    private final Iterator<Changeset> changesetIterator;
+    private final Commit releaseChangeset;
+    private final Iterator<Commit> changesetIterator;
     private final CommitMessageVersionExtractor commitMessageVersionExtractor;
 
     public JiraVersionGenerator(@Nonnull JiraService jiraService,
-                                @Nonnull Changeset releaseChangeset,
-                                @Nonnull Iterator<Changeset> changesetIterator,
+                                @Nonnull Commit releaseChangeset,
+                                @Nonnull Iterator<Commit> changesetIterator,
                                 @Nonnull CommitMessageVersionExtractor commitMessageVersionExtractor) {
 
         this.releaseChangeset = releaseChangeset;
@@ -65,7 +65,7 @@ public class JiraVersionGenerator {
             return;
         }
 
-        List<Changeset> versionChangesets = getVersionChangesets();
+        List<Commit> versionChangesets = getVersionChangesets();
 
         Version version = Version.of(jiraVersionPrefix + versionName.get(),
                                      projectKey,
@@ -107,11 +107,11 @@ public class JiraVersionGenerator {
 
     }
 
-    private List<IssueKey> getIssueKeys(List<Changeset> versionChangesets, ProjectKey projectKey) {
+    private List<IssueKey> getIssueKeys(List<Commit> versionChangesets, ProjectKey projectKey) {
 
         List<IssueKey> issueKeys = new ArrayList<>();
 
-        for (Changeset versionChangeset : versionChangesets) {
+        for (Commit versionChangeset : versionChangesets) {
             Iterable<IssueKey> issueKeyIterable = IssueKey.of(versionChangeset);
 
             for (IssueKey issueKey : issueKeyIterable) {
@@ -124,12 +124,12 @@ public class JiraVersionGenerator {
         return issueKeys;
     }
 
-    private List<Changeset> getVersionChangesets() {
+    private List<Commit> getVersionChangesets() {
 
-        List<Changeset> versionChangesets = new ArrayList<>();
+        List<Commit> versionChangesets = new ArrayList<>();
 
         while (changesetIterator.hasNext()) {
-            Changeset changeset = changesetIterator.next();
+            Commit changeset = changesetIterator.next();
 
             if (commitMessageVersionExtractor.extractVersionName(changeset.getMessage()).isPresent()) {
                 break;

--- a/src/test/java/com/infobip/jira/Changeset.java
+++ b/src/test/java/com/infobip/jira/Changeset.java
@@ -15,8 +15,9 @@
  */
 package com.infobip.jira;
 
+import com.atlassian.stash.commit.MinimalCommit;
 import com.atlassian.stash.content.AttributeMap;
-import com.atlassian.stash.content.MinimalChangeset;
+import com.atlassian.stash.property.PropertyMap;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.user.Person;
 
@@ -31,7 +32,7 @@ import java.util.Set;
 /**
  * @author lpandzic
  */
-class Changeset implements com.atlassian.stash.content.Changeset {
+class Changeset implements com.atlassian.stash.commit.Commit {
 
 	private final String message;
 	private final String id;
@@ -78,7 +79,7 @@ class Changeset implements com.atlassian.stash.content.Changeset {
 	}
 
 	@Override
-	public Collection<MinimalChangeset> getParents() {
+	public Collection<MinimalCommit> getParents() {
 
 		return null;
 	}
@@ -114,5 +115,11 @@ class Changeset implements com.atlassian.stash.content.Changeset {
 	public String getId() {
 
 		return id;
+	}
+
+	@Nonnull
+	@Override
+	public PropertyMap getProperties() {
+		return PropertyMap.EMPTY;
 	}
 }

--- a/src/test/java/com/infobip/jira/JiraVersionGeneratorHookTest.java
+++ b/src/test/java/com/infobip/jira/JiraVersionGeneratorHookTest.java
@@ -17,9 +17,7 @@ package com.infobip.jira;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.times;
 
 import java.io.IOException;
@@ -27,6 +25,9 @@ import java.util.Date;
 
 import com.atlassian.applinks.api.CredentialsRequiredException;
 import com.atlassian.sal.api.net.ResponseException;
+import com.atlassian.stash.commit.Commit;
+import com.atlassian.stash.commit.CommitService;
+import com.atlassian.stash.commit.CommitsRequest;
 import com.atlassian.stash.history.HistoryService;
 import com.atlassian.stash.hook.repository.RepositoryHookContext;
 import com.atlassian.stash.repository.RefChange;
@@ -41,6 +42,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.verification.VerificationMode;
@@ -52,7 +54,7 @@ public class JiraVersionGeneratorHookTest {
 	private JiraVersionGeneratorHook jiraVersionGeneratorHook;
 
 	@Mock
-	private HistoryService historyService;
+	private CommitService historyService;
 
 	@Mock
 	private JiraService jiraService;
@@ -64,7 +66,7 @@ public class JiraVersionGeneratorHookTest {
 	private Repository repository;
 
 	@Mock
-	private Page<com.atlassian.stash.content.Changeset> changesetPage;
+	private Page<Commit> changesetPage;
 
 	@Mock
 	private RefChange latestRefChange;
@@ -272,12 +274,10 @@ public class JiraVersionGeneratorHookTest {
 		given(latestRefChange.getRefId()).willReturn(branchName);
 	}
 
-	private void givenChangesets(com.atlassian.stash.content.Changeset... changesets) {
+	private void givenChangesets(Commit... changesets) {
 
 		given(changesetPage.getValues()).willReturn(ImmutableList.copyOf(changesets));
-		given(historyService.getChangesets(any(Repository.class),
-		                                   anyString(),
-		                                   anyString(),
+		given(historyService.getCommits(any(CommitsRequest.class),
 		                                   any(PageRequest.class))).willReturn(changesetPage);
 	}
 
@@ -304,9 +304,9 @@ public class JiraVersionGeneratorHookTest {
 
 	private void thenGetChangesets(VerificationMode verificationMode, String branchName) {
 
-		then(historyService).should(verificationMode).getChangesets(eq(repository),
-		                                                            eq(branchName),
-		                                                            anyString(),
+		CommitsRequest request = new CommitsRequest.Builder(repository, branchName).build();
+
+		then(historyService).should(verificationMode).getCommits(refEq(request),
 		                                                            any(PageRequest.class));
 	}
 

--- a/src/test/java/com/infobip/jira/JiraVersionGeneratorTest.java
+++ b/src/test/java/com/infobip/jira/JiraVersionGeneratorTest.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 
 import com.atlassian.applinks.api.CredentialsRequiredException;
 import com.atlassian.sal.api.net.ResponseException;
+import com.atlassian.stash.commit.Commit;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +45,7 @@ public class JiraVersionGeneratorTest {
 	private JiraService jiraService;
 
 	@Mock
-	private Iterator<com.atlassian.stash.content.Changeset> changesetIterator;
+	private Iterator<Commit> changesetIterator;
 
 	@Test
 	public void shouldCheckIfCorrectJiraVersionExists() throws IOException, CredentialsRequiredException, ResponseException {


### PR DESCRIPTION
The API in Stash was changed with version 3, so the plugin didn't work properly.
This commit updates the dependency to Stash 3.7.2 and uses the new APIs
(like Commit instead of Changeset etc.).

We had problems to install this plugin in our Stash instance which runs on version 3.7.2. So i updated the plugin to reflect the current API and remove deprecated API calls etc. Feel free to incorporate this pull request into your codebase.

Testing with Stash/Bitbucket Server 4.0 still pending, but i think with the current API usage it should work.
