### PR TITLE
Single commit release fix

### DIFF
--- a/src/main/java/com/infobip/bitbucket/CommitPageCrawler.java
+++ b/src/main/java/com/infobip/bitbucket/CommitPageCrawler.java
@@ -40,7 +40,7 @@ class CommitPageCrawler implements Iterator<Commit> {
 
         Function<PageRequest, Page<Commit>> pageProvider = pageRequest -> {
             CommitsBetweenRequest request = new CommitsBetweenRequest.Builder(repository)
-                    .include(from.getFromHash())
+                    .include(from.getToHash())
                     .build();
 
             return commitService.getCommitsBetween(request, pageRequest);

--- a/src/test/java/com/infobip/jira/JiraVersionGeneratorHookTest.java
+++ b/src/test/java/com/infobip/jira/JiraVersionGeneratorHookTest.java
@@ -81,8 +81,8 @@ public class JiraVersionGeneratorHookTest {
         given(repositoryHookContext.getSettings()).willReturn(settings);
         given(settings.getString(anyString(), eq(""))).willReturn("");
         given(repositoryHookContext.getRepository()).willReturn(repository);
-        given(latestRefChange.getFromHash()).willReturn("latestRefChange");
-        given(olderRefChange.getFromHash()).willReturn("olderRefChange");
+        given(latestRefChange.getToHash()).willReturn("latestRefChange");
+        given(olderRefChange.getToHash()).willReturn("olderRefChange");
     }
 
     @Test
@@ -270,7 +270,7 @@ public class JiraVersionGeneratorHookTest {
 
     private void givenCommits(RefChange refChange, Commit... commits) {
 
-        CommitsBetweenRequest request = new CommitsBetweenRequest.Builder(repository).include(refChange.getFromHash()).build();
+        CommitsBetweenRequest request = new CommitsBetweenRequest.Builder(repository).include(refChange.getToHash()).build();
         given(commitService.getCommitsBetween(refEq(request), any())).willReturn(new PageImpl<>(null, Arrays.asList(commits), true));
     }
 
@@ -292,7 +292,7 @@ public class JiraVersionGeneratorHookTest {
     private void thenGetCommits(VerificationMode verificationMode, RefChange refChange) {
 
         CommitsBetweenRequest request = new CommitsBetweenRequest.Builder(repository)
-                .include(refChange.getFromHash())
+                .include(refChange.getToHash())
                 .build();
 
         then(commitService).should(verificationMode).getCommitsBetween(refEq(request),


### PR DESCRIPTION
Fixed a bug that caused version generator to create a version only after another commit was pushed.

This was unnoticed due to the fact that Maven release always creates 2 commits - 1st with a tag and release message, and second with a snapshot version.