### PR TITLE
Upgrade to Bitbucket Server 9.4.17 and Java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
           java-version: 17

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 17
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Coveralls Maven plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.0.0
+
+  - upgrade to Bitbucket Server 9.4.17
+  - upgrade to Java 17
+  - upgrade Lombok from 1.18.20 to 1.18.44 (1.18.22+ required for Java 17 support)
+  - upgrade Mockito from 1.x to 5.23.0 (1.x uses cglib which is incompatible with Java 17 module system)
+  - upgrade JaCoCo from 0.8.5 to 0.8.14 (0.8.5 does not support Java 17 class file format)
+  - upgrade Jackson modules to 2.17.3 (aligned with Bitbucket Server BOM)
+  - remove Guava dependency (Bitbucket Server DMZ blocks `com.google.common` packages from plugins; replaced with standard Java utilities: `List.of()`, `String.isEmpty()`)
+  - remove unused joda-time imports
+  - bundle Jackson modules (jsr310, jdk8, parameter-names) with jackson-core excluded (Bitbucket Server DMZ blocks these packages from plugins, but jackson-core/databind are exported by the platform)
+
 ## 2.0.1
 
   - upgrade to Bitbucket Server 6.5.1

--- a/pom.xml
+++ b/pom.xml
@@ -63,25 +63,25 @@
 
 	<properties>
 		<!-- DEPENDENCY VERSIONS -->
-		<bitbucket.version>6.5.1</bitbucket.version>
-		<amps.version>8.0.1</amps.version>
+		<bitbucket.version>9.4.17</bitbucket.version>
+		<amps.version>9.9.1</amps.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<jackson.version>2.12.4</jackson.version>
 		<assertj-core.version>3.5.2</assertj-core.version>
-		<mockito-core.version>1.10.19</mockito-core.version>
-		<bitbucket.data.version>4.8.2</bitbucket.data.version>
+		<mockito-core.version>5.23.0</mockito-core.version>
+		<bitbucket.data.version>9.4.17</bitbucket.data.version>
 
-		<lombok.version>1.18.20</lombok.version>
+		<lombok.version>1.18.44</lombok.version>
 
 		<!-- PLUGIN VERSIONS -->
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 		<coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
-		<jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-		<bitbucket-maven-plugin.version>1.30.5</bitbucket-maven-plugin.version>
+		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+		<quickreload-plugin.version>6.2.1</quickreload-plugin.version>
 
 		<!-- OTHER PROPERTIES -->
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 	</properties>
@@ -102,22 +102,37 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jdk8</artifactId>
-			<version>${jackson.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.module</groupId>
-			<artifactId>jackson-module-parameter-names</artifactId>
-			<version>${jackson.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
-			<version>${jackson.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-parameter-names</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.atlassian.sal</groupId>
@@ -156,6 +171,7 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<version>${lombok.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -193,7 +209,7 @@
 						<pluginArtifact>
 							<groupId>com.atlassian.labs.plugins</groupId>
 							<artifactId>quickreload</artifactId>
-							<version>${bitbucket-maven-plugin.version}</version>
+							<version>${quickreload-plugin.version}</version>
 						</pluginArtifact>
 					</pluginArtifacts>
 				</configuration>
@@ -208,6 +224,13 @@
 					<compilerArgument>-parameters</compilerArgument>
 					<testCompilerArgument>-parameters</testCompilerArgument>
 					<encoding>utf8</encoding>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.infobip</groupId>
 	<artifactId>jira-version-generator</artifactId>
-	<version>2.0.2-SNAPSHOT</version>
+	<version>3.0.0</version>
 	<packaging>atlassian-plugin</packaging>
 
 	<name>Jira Version Generator</name>

--- a/src/main/java/com/infobip/bitbucket/JiraVersionGeneratorHook.java
+++ b/src/main/java/com/infobip/bitbucket/JiraVersionGeneratorHook.java
@@ -20,8 +20,7 @@ import com.atlassian.bitbucket.hook.repository.*;
 import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.scope.Scope;
 import com.atlassian.bitbucket.setting.*;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 import com.infobip.infrastructure.ClockFactory;
 import com.infobip.jira.*;
 import org.slf4j.Logger;
@@ -36,14 +35,14 @@ public class JiraVersionGeneratorHook implements PostRepositoryHook, SettingsVal
 
     private final CommitService commitService;
     private final JiraService jiraService;
-    private final ImmutableList<SettingsValidator> settingsValidators;
+    private final List<SettingsValidator> settingsValidators;
 
     public JiraVersionGeneratorHook(CommitService commitService, JiraService jiraService) {
 
         this.commitService = commitService;
         this.jiraService = jiraService;
 
-        settingsValidators = ImmutableList.of(new ProjectKeyValidator(), new VersionPatternValidator());
+        settingsValidators = List.of(new ProjectKeyValidator(), new VersionPatternValidator());
     }
 
     @Override
@@ -83,14 +82,15 @@ public class JiraVersionGeneratorHook implements PostRepositoryHook, SettingsVal
     }
 
     private Optional<String> getNonEmptySetting(RepositoryHookContext context, String key) {
-        String setting = Strings.emptyToNull(context.getSettings().getString(key));
+        String setting = context.getSettings().getString(key);
+        setting = (setting == null || setting.isEmpty()) ? null : setting;
         return Optional.ofNullable(setting);
     }
 
     private String requireNonEmptySetting(RepositoryHookContext context, String key) {
         String setting = context.getSettings().getString(key);
 
-        if (Strings.isNullOrEmpty(setting)) {
+        if (setting == null || setting.isEmpty()) {
             String message = String.format("%s hook setting is not set to a non empty value", key);
             throw new IllegalStateException(message);
         }

--- a/src/main/java/com/infobip/jira/Version.java
+++ b/src/main/java/com/infobip/jira/Version.java
@@ -16,11 +16,8 @@
 package com.infobip.jira;
 
 import lombok.Value;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 import java.time.LocalDate;
-import java.util.Optional;
 
 @Value
 public class Version {

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -3,6 +3,7 @@
 		<description>${project.description}</description>
 		<version>${project.version}</version>
 		<vendor name="${project.organization.name}" url="${project.organization.url}" />
+		<param name="application-version.min">9.4.17</param>
 	</plugin-info>
 
 	<component-import key="applicationLinkService" interface="com.atlassian.applinks.api.ApplicationLinkService" />

--- a/src/test/java/com/infobip/bitbucket/ProjectKeyValidatorTest.java
+++ b/src/test/java/com/infobip/bitbucket/ProjectKeyValidatorTest.java
@@ -21,12 +21,12 @@ import com.atlassian.bitbucket.setting.SettingsValidationErrors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/com/infobip/bitbucket/VersionPatternValidatorTest.java
+++ b/src/test/java/com/infobip/bitbucket/VersionPatternValidatorTest.java
@@ -21,12 +21,12 @@ import com.atlassian.bitbucket.setting.SettingsValidationErrors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/com/infobip/jira/JiraServiceTest.java
+++ b/src/test/java/com/infobip/jira/JiraServiceTest.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.*;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -30,8 +30,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JiraServiceTest {

--- a/src/test/java/com/infobip/jira/JiraVersionGeneratorHookTest.java
+++ b/src/test/java/com/infobip/jira/JiraVersionGeneratorHookTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.verification.VerificationMode;
 
 import java.io.IOException;
@@ -41,10 +41,10 @@ import java.util.*;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.refEq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.times;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -83,7 +83,6 @@ public class JiraVersionGeneratorHookTest {
     public void setUp() {
 
         given(context.getSettings()).willReturn(settings);
-        given(settings.getString(anyString(), eq(""))).willReturn("");
         given(request.getRepository()).willReturn(repository);
         given(latestRefChange.getToHash()).willReturn("latestRefChange");
         given(olderRefChange.getToHash()).willReturn("olderRefChange");

--- a/src/test/java/com/infobip/jira/JiraVersionGeneratorTest.java
+++ b/src/test/java/com/infobip/jira/JiraVersionGeneratorTest.java
@@ -20,12 +20,12 @@ import com.atlassian.bitbucket.commit.Commit;
 import com.atlassian.bitbucket.commit.SimpleCommit;
 import com.atlassian.bitbucket.user.TestApplicationUser;
 import com.atlassian.sal.api.net.ResponseException;
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -34,7 +34,7 @@ import java.util.*;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JiraVersionGeneratorTest {
@@ -110,7 +110,7 @@ public class JiraVersionGeneratorTest {
 
         then(jiraService).should().addVersionToIssues("1.0.1",
                 new ProjectKey("TEST"),
-                ImmutableList.of(new IssueKey(new ProjectKey("TEST"), new IssueId("1"))));
+                List.of(new IssueKey(new ProjectKey("TEST"), new IssueId("1"))));
     }
 
     @Test


### PR DESCRIPTION
## 3.0.0

  - upgrade to Bitbucket Server 9.4.17
  - upgrade to Java 17
  - upgrade Lombok from 1.18.20 to 1.18.44 (1.18.22+ required for Java 17 support)
  - upgrade Mockito from 1.x to 5.23.0 (1.x uses cglib which is incompatible with Java 17 module system)
  - upgrade JaCoCo from 0.8.5 to 0.8.14 (0.8.5 does not support Java 17 class file format)
  - upgrade Jackson modules to 2.17.3 (aligned with Bitbucket Server BOM)
  - remove Guava dependency (Bitbucket Server DMZ blocks `com.google.common` packages from plugins; replaced with standard Java utilities: `List.of()`, `String.isEmpty()`)
  - remove unused joda-time imports
  - bundle Jackson modules (jsr310, jdk8, parameter-names) with jackson-core excluded (Bitbucket Server DMZ blocks these packages from plugins, but jackson-core/databind are exported by the platform)
  
  
  Minimal support now is version 9.4.17